### PR TITLE
add the requirement option to the Auth and Sign Payload (#9)

### DIFF
--- a/lib/ex_bank_id/auth.ex
+++ b/lib/ex_bank_id/auth.ex
@@ -13,6 +13,7 @@ defmodule ExBankID.Auth do
         type: :string
         # TODO: Add validator
       ],
+      requirement: [],
       http_client: [
         type: :atom,
         default: Application.get_env(:ex_bank_id, :http_client, ExBankID.Http.Default)

--- a/lib/ex_bank_id/payload_helpers.ex
+++ b/lib/ex_bank_id/payload_helpers.ex
@@ -1,0 +1,253 @@
+defmodule ExBankID.PayloadHelpers do
+  @moduledoc """
+  Checkers for Payload options
+
+  https://www.bankid.com/assets/bankid/rp/bankid-relying-party-guidelines-v3.4.pdf
+  """
+
+  @doc """
+  Returns {:ok, ip_addres} or {:error, reason} for IP address validity
+
+  ## Examples
+      iex> ExBankID.PayloadHelpers.check_ip_address("1.1.1.1")
+      {:ok, "1.1.1.1"}
+
+      iex> ExBankID.PayloadHelpers.check_ip_address("345.0.0.0")
+      {:error, "Invalid ip address: 345.0.0.0"}
+  """
+  def check_ip_address(ip_address)
+       when is_binary(ip_address) do
+    ip_address_cl = String.to_charlist(ip_address)
+
+    case :inet.parse_strict_address(ip_address_cl) do
+      {:ok, _} ->
+        {:ok, ip_address}
+
+      _ ->
+        {:error, "Invalid ip address: #{ip_address}"}
+    end
+  end
+
+  @doc """
+  Returns {:ok, personal_number} or {:error, reason} for personal number
+
+  ## Examples
+      iex> ExBankID.PayloadHelpers.check_personal_number("190000000000")
+      {:ok, "190000000000"}
+
+      iex> ExBankID.PayloadHelpers.check_personal_number("42")
+      {:error, "Invalid personal number: 42"}
+  """
+  def check_personal_number(personal_number)
+       when is_binary(personal_number) do
+    # TODO: Implement relevant personal number check.
+    case String.length(personal_number) do
+      12 ->
+        {:ok, personal_number}
+
+      _ ->
+        {:error, "Invalid personal number: #{personal_number}"}
+    end
+  end
+
+  @doc """
+  Returns {:ok, nil} when personal number is omitted
+
+  ## Examples
+      iex> ExBankID.PayloadHelpers.check_personal_number(nil)
+      {:ok, nil}
+  """
+  def check_personal_number(nil) do
+    {:ok, nil}
+  end
+
+  @doc """
+  Returns {:ok, nil} when requirement is omitted
+
+  ## Examples
+      iex> ExBankID.PayloadHelpers.check_requirement(nil)
+      {:ok, nil}
+  """
+  def check_requirement(nil), do: {:ok, nil}
+
+  @doc """
+  Returns {:ok, requirement} when all requirement's keys are valid
+
+  ## Examples
+      iex> ExBankID.PayloadHelpers.check_requirement(%{allowFingerprint: :true, cardReader: "class1"})
+      {:ok, %{allowFingerprint: :true, cardReader: "class1"}}
+
+      iex> ExBankID.PayloadHelpers.check_requirement(%{tokenStartRequired: :false, notRealRequirement: "fails"})
+      {:error, "Invalid requirement"}
+  """
+  def check_requirement(%{} = requirement) do
+    if Enum.all?(
+         Enum.map(
+           Map.keys(requirement),
+           fn key -> check_requirement(key, requirement[key]) end
+         ),
+         fn result -> result == {:ok, nil} end
+       ) do
+      {:ok, requirement}
+    else
+      {:error, "Invalid requirement"}
+    end
+  end
+
+  @doc """
+  Returns {:ok, nil} when requirement is anything besides a map or nil
+
+  ## Examples
+      iex> ExBankID.PayloadHelpers.check_requirement("something")
+      {:error, "Invalid requirement"}
+  """
+  def check_requirement(_), do: {:error, "Invalid requirement"}
+
+  def check_requirement(:allowFingerprint, value) when is_boolean(value), do: {:ok, nil}
+
+  @deprecated "Will not be possible to use in future versions of the RP API. Use tokenStartRequired."
+  @doc """
+  Returns {:ok, nil} when autoStartTokenRequired is a boolean
+
+  ## Examples
+      iex> ExBankID.PayloadHelpers.check_requirement(:autoStartTokenRequired, :false)
+      {:ok, nil}
+
+      iex> ExBankID.PayloadHelpers.check_requirement(:autoStartTokenRequired, "true")
+      {:error, "Invalid requirement"}
+  """
+  def check_requirement(:autoStartTokenRequired, value) when is_boolean(value), do: {:ok, nil}
+
+  @doc """
+  Returns {:ok, nil} when cardReader is "class1" or "class2"
+
+  ## Examples
+      iex> ExBankID.PayloadHelpers.check_requirement(:cardReader, "class1")
+      {:ok, nil}
+
+      iex> ExBankID.PayloadHelpers.check_requirement(:cardReader, "class3")
+      {:error, "Invalid requirement"}
+  """
+  def check_requirement(:cardReader, value) when is_binary(value) do
+    case value do
+      "class1" -> {:ok, nil}
+      "class2" -> {:ok, nil}
+      _ -> {:error, "Invalid requirement"}
+    end
+  end
+
+  @doc """
+  Returns {:error, "Invalid requirement"} when certificatePolicies is an empty list
+
+  ## Examples
+      iex> ExBankID.PayloadHelpers.check_requirement(:certificatePolicies, [])
+      {:error, "Invalid requirement"}
+  """
+  def check_requirement(:certificatePolicies, []), do: {:error, "Invalid requirement"}
+
+  @doc """
+  Returns {:ok, nil} when certificatePolicies is a list of oid's
+
+  One wildcard "*" is allowed from position 5 and forward ie. 1.2.752.78.*
+
+  ## Examples
+      iex> ExBankID.PayloadHelpers.check_requirement(:certificatePolicies, ["1.2.752.78.*", "1.2.752.78.1.5"])
+      {:ok, nil}
+
+      iex> ExBankID.PayloadHelpers.check_requirement(:certificatePolicies, ["not an oid"])
+      {:error, "Invalid requirement"}
+  """
+  def check_requirement(:certificatePolicies, value) when is_list(value) do
+    if Enum.all?(value, fn oid -> oid?(oid) end) do
+      {:ok, nil}
+    else
+      {:error, "Invalid requirement"}
+    end
+  end
+
+  @doc """
+  Returns {:error, "Invalid requirement"} when issuerCn is an empty list
+
+  ## Examples
+      iex> ExBankID.PayloadHelpers.check_requirement(:certificatePolicies, [])
+      {:error, "Invalid requirement"}
+  """
+  def check_requirement(:issuerCn, []), do: {:error, "Invalid requirement"}
+
+  @doc """
+  Returns {:ok, nil} when issuerCn is a list of strings
+
+  ## Examples
+      iex> ExBankID.PayloadHelpers.check_requirement(:issuerCn, ["Nordea CA for Smartcard users 12", "Nordea Test CA for Softcert users 13"])
+      {:ok, nil}
+
+      iex> ExBankID.PayloadHelpers.check_requirement(:issuerCn, "Nordea Test CA for Softcert users 13")
+      {:error, "Invalid requirement"}
+  """
+  def check_requirement(:issuerCn, value) when is_list(value) do
+    if Enum.all?(value, fn cn -> is_binary(cn) end) do
+      {:ok, nil}
+    else
+      {:error, "Invalid requirement"}
+    end
+  end
+
+  @doc """
+  Returns {:ok, nil} when tokenStartRequired is a boolean
+
+  ## Examples
+      iex> ExBankID.PayloadHelpers.check_requirement(:tokenStartRequired, :false)
+      {:ok, nil}
+
+      iex> ExBankID.PayloadHelpers.check_requirement(:tokenStartRequired, "true")
+      {:error, "Invalid requirement"}
+  """
+  def check_requirement(:tokenStartRequired, value) when is_boolean(value), do: {:ok, nil}
+
+  @doc """
+  Returns {:error, "Invalid requirement"} when key, value is anything else besides above permitted
+
+  ## Examples
+      iex> ExBankID.PayloadHelpers.check_requirement(:foo, "bar")
+      {:error, "Invalid requirement"}
+  """
+  def check_requirement(_, _), do: {:error, "Invalid requirement"}
+
+  @doc """
+  Returns true when value is an oid
+
+  One wildcard "*" is allowed from position 5 and forward ie. 1.2.752.78.*
+
+  ## Examples
+      iex> ExBankID.PayloadHelpers.oid?("1.2.752.78.*")
+      true
+
+      iex> ExBankID.PayloadHelpers.oid?("1.2.3.4.5.6.7.8.9.10.11.13")
+      true
+
+      iex> ExBankID.PayloadHelpers.oid?("1.2.3.4.5.6.7.8.9.10.11.13.14")
+      false
+
+      iex> ExBankID.PayloadHelpers.oid?("1.2.3.4.5")
+      true
+
+      iex> ExBankID.PayloadHelpers.oid?("1.2.3.4.*")
+      true
+
+      iex> ExBankID.PayloadHelpers.oid?("1.2.3.*")
+      false
+  """
+  def oid?(value) when is_binary(value) do
+    value =~ ~r/^([1-9][0-9]{0,3}|0)(\.([1-9][0-9]{0,3}|0)){5,13}$/ or
+      value =~ ~r/^([1-9][0-9]{0,3}|0)(\.([1-9][0-9]{0,3}|0)){3}(\.([1-9][0-9]{0,3}|0|\*)){0,9}$/
+  end
+
+  @doc """
+  Returns false when arg is anything other than a string
+
+  ## Examples
+      iex> ExBankID.PayloadHelpers.oid?(:foo)
+      false
+  """
+  def oid?(_), do: false
+end

--- a/lib/ex_bank_id/sign.ex
+++ b/lib/ex_bank_id/sign.ex
@@ -15,6 +15,7 @@ defmodule ExBankID.Sign do
         type: :string
         # TODO: Add validator
       ],
+      requirement: [],
       user_non_visible_data: [
         type: :string
       ],

--- a/lib/ex_bank_id/sign/payload.ex
+++ b/lib/ex_bank_id/sign/payload.ex
@@ -2,12 +2,15 @@ defmodule ExBankID.Sign.Payload do
   @moduledoc """
   Provides the struct used when initiating a signing of data
   """
-  defstruct [:endUserIp, :personalNumber, :userVisibleData, :userNonVisibleData]
+  defstruct [:endUserIp, :personalNumber, :requirement, :userVisibleData, :userNonVisibleData]
+
+  import ExBankID.PayloadHelpers
 
   @spec new(
           binary,
           binary,
           personal_number: String.t(),
+          requirement: map(),
           user_non_visible_data: String.t()
         ) ::
           {:error, String.t()} | %ExBankID.Sign.Payload{}
@@ -22,8 +25,11 @@ defmodule ExBankID.Sign.Payload do
       iex> ExBankID.Sign.Payload.new("1.1.1.1", "This will be visible in the bankID app", personal_number: "190000000000")
       %ExBankID.Sign.Payload{endUserIp: "1.1.1.1", personalNumber: "190000000000", userVisibleData: "VGhpcyB3aWxsIGJlIHZpc2libGUgaW4gdGhlIGJhbmtJRCBhcHA="}
 
+      iex> ExBankID.Sign.Payload.new("1.1.1.1", "This will be visible in the bankID app", requirement: %{allowFingerprint: :false})
+      %ExBankID.Sign.Payload{endUserIp: "1.1.1.1", userVisibleData: "VGhpcyB3aWxsIGJlIHZpc2libGUgaW4gdGhlIGJhbmtJRCBhcHA=", requirement: %{allowFingerprint: :false}}
+
       iex> ExBankID.Sign.Payload.new("Not a valid ip address", "This will be visible in the bankID app", personal_number: "190000000000")
-      {:error, "Invalid ip address Not a valid ip address"}
+      {:error, "Invalid ip address: Not a valid ip address"}
   """
   def new(ip_address, user_visible_data, opts \\ [])
       when is_binary(ip_address) and is_binary(user_visible_data) and is_list(opts) do
@@ -31,43 +37,16 @@ defmodule ExBankID.Sign.Payload do
          {:ok, user_visible_data} <- encode_user_visible_data(user_visible_data),
          {:ok, personal_number} <- check_personal_number(Keyword.get(opts, :personal_number)),
          {:ok, user_non_visible_data} <-
-           encode_user_non_visible_data(Keyword.get(opts, :user_non_visible_data)) do
+           encode_user_non_visible_data(Keyword.get(opts, :user_non_visible_data)),
+         {:ok, requirement} <- check_requirement(Keyword.get(opts, :requirement)) do
       %ExBankID.Sign.Payload{
         endUserIp: ip_address,
         userVisibleData: user_visible_data,
         personalNumber: personal_number,
+        requirement: requirement,
         userNonVisibleData: user_non_visible_data
       }
     end
-  end
-
-  defp check_ip_address(ip_address)
-       when is_binary(ip_address) do
-    ip_address_cl = String.to_charlist(ip_address)
-
-    case :inet.parse_strict_address(ip_address_cl) do
-      {:ok, _} ->
-        {:ok, ip_address}
-
-      _ ->
-        {:error, "Invalid ip address #{ip_address}"}
-    end
-  end
-
-  defp check_personal_number(personal_number)
-       when is_binary(personal_number) do
-    # TODO: Implement relevant personal number check.
-    case String.length(personal_number) do
-      12 ->
-        {:ok, personal_number}
-
-      _ ->
-        {:error, "Invalid personal number"}
-    end
-  end
-
-  defp check_personal_number(nil) do
-    {:ok, nil}
   end
 
   defp encode_user_visible_data(data) when is_binary(data) do

--- a/test/auth/client_test.exs
+++ b/test/auth/client_test.exs
@@ -68,8 +68,45 @@ defmodule Test.Auth.Client do
              )
   end
 
+  test "client handles successful auth request with requirement", %{bypass: bypass} do
+    expected_response =
+      {:ok,
+       %ExBankID.Auth.Response{
+         orderRef: "131daac9-16c6-4618-beb0-365768f37288",
+         autoStartToken: "7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6",
+         qrStartToken: "67df3917-fa0d-44e5-b327-edcc928297f8",
+         qrStartSecret: "d28db9a7-4cde-429e-a983-359be676944c"
+       }}
+
+    expected_request_payload = %{
+      "endUserIp" => "1.1.1.1",
+      "requirement" => %{"allowFingerprint" => true}
+    }
+
+    response_payload = ~s<{
+    "orderRef": "131daac9-16c6-4618-beb0-365768f37288",
+    "autoStartToken": "7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6",
+    "qrStartToken": "67df3917-fa0d-44e5-b327-edcc928297f8",
+    "qrStartSecret": "d28db9a7-4cde-429e-a983-359be676944c"
+    }>
+
+    Bypass.expect_once(
+      bypass,
+      "POST",
+      "/auth",
+      Test.Helpers.endpoint_handler(200, response_payload, expected_request_payload)
+    )
+
+    assert ^expected_response =
+             ExBankID.auth("1.1.1.1",
+               url: Test.Helpers.get_url(bypass.port()),
+               requirement: %{allowFingerprint: true}
+             )
+  end
+
   test "client handles unsuccessful auth request", %{bypass: bypass} do
-    expected_response = {:error, %ExBankID.Error.Api{errorCode: "invalidParameters", details: "No such order"}}
+    expected_response =
+      {:error, %ExBankID.Error.Api{errorCode: "invalidParameters", details: "No such order"}}
 
     expected_request_payload = %{"endUserIp" => "1.1.1.1"}
 

--- a/test/doc/doc_test.exs
+++ b/test/doc/doc_test.exs
@@ -3,4 +3,5 @@ defmodule ExBankID.Auth.PayloadTest do
   doctest ExBankID.Auth.Payload
   doctest ExBankID.Sign.Payload
   doctest ExBankID.Cancel.Payload
+  doctest ExBankID.PayloadHelpers
 end

--- a/test/sign/client_test.exs
+++ b/test/sign/client_test.exs
@@ -50,6 +50,28 @@ defmodule Test.Auth.Sign do
              )
   end
 
+  test "client handles successful sign request with request", %{bypass: bypass} do
+    Bypass.expect_once(bypass, "POST", "/sign", fn conn ->
+      Plug.Conn.resp(
+        conn,
+        200,
+        ~s<{"orderRef":"131daac9-16c6-4618-beb0-365768f37288","autoStartToken":"7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6","qrStartToken":"67df3917-fa0d-44e5-b327-edcc928297f8","qrStartSecret":"d28db9a7-4cde-429e-a983-359be676944c"}>
+      )
+    end)
+
+    assert {:ok,
+            %ExBankID.Sign.Response{
+              orderRef: "131daac9-16c6-4618-beb0-365768f37288",
+              autoStartToken: "7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6",
+              qrStartToken: "67df3917-fa0d-44e5-b327-edcc928297f8",
+              qrStartSecret: "d28db9a7-4cde-429e-a983-359be676944c"
+            }} =
+             ExBankID.sign("1.1.1.1", "Visible data",
+               url: Test.Helpers.get_url(bypass.port()),
+               requirement: %{issuerCn: ["test"]}
+             )
+  end
+
   test "client handles successful sign request with personal number and non visible data", %{
     bypass: bypass
   } do


### PR DESCRIPTION
Adds a `requirement` option to the `Auth.Payload` and `Sign.Payload`.  Moves the payload validations into a new `ExBankID.PayloadHelpers` module.  New module has doctests.  Also adds tests for the clients.